### PR TITLE
修复带参考基因压缩不打包场景解压失败问题

### DIFF
--- a/src/compress_engine.cpp
+++ b/src/compress_engine.cpp
@@ -108,13 +108,16 @@ bool CompressEngine::initReference() {
         refeMeta["fasta_md5"] = pRefGene->getFastaChecksum();
         refeMeta["ni_name"] = PathUtil::getFileName(pRefGene->getNiFilePath()); /* Contains md5 information, used for decompression verification */
         refeMeta["max_block_len"] = 16 << 20;
-        refeMeta["blocks"] = calcPackRefeBlockSize();
-        baseFileMeta.setMetaData("refe",refeMeta);
         bool isPackRefeInHeader = !parameter.isUnpackRef && parameter.outputFile == "/dev/stdout";
         if (isPackRefeInHeader) {
+            refeMeta["blocks"] = calcPackRefeBlockSize();
+            baseFileMeta.setMetaData("refe",refeMeta);
             int64_t maxRefLen = 0;
             int64_t totolEncLen = 0;
             (void)packReference(maxRefLen, totolEncLen, false);
+        } else {
+            refeMeta["blocks"] = 0;
+            baseFileMeta.setMetaData("refe",refeMeta);
         }
     }
     return true;

--- a/src/decompress_engine.cpp
+++ b/src/decompress_engine.cpp
@@ -21,7 +21,6 @@ BlockReader* DecompressEngine::createBlockReader() {
     if (parameter.inputFile != "/dev/stdin" && !parameter.refeGenePos.empty()) {
         if (!initRefeIndex(pbgzReader)) {
             LOG_INFO("Init reference index for decompress failed");
-            MemoryUtil::safeDeleteClass(pbgzReader);
         }
     }
 

--- a/src/pbgz_engine.cpp
+++ b/src/pbgz_engine.cpp
@@ -264,6 +264,9 @@ void PbgzEngine::readBlocks(BlockReader* blockReader) {
 int32_t PbgzEngine::startReadTask() {
     pthread_setname_np(pthread_self(), "readtask");
     BlockReader* blockReader = createBlockReader();
+    if (blockReader == nullptr) {
+        return -1;
+    }
     readBlocks(blockReader);
     // Reached end of file or error, insert empty block as end marker to data queue
     for (uint32_t i = 0; i < parameter.threadNum; ++i) {
@@ -349,6 +352,10 @@ int32_t PbgzEngine::startWriteTask() {
     auto writerTask = [this]() -> int32_t {
         pthread_setname_np(pthread_self(), "writetask");
         BlockWriter* blockWriter = createBlockWriter();
+        if (blockWriter == nullptr) {
+            PbgzManager::getInstance().exitProc(-1, "Inner error");
+            return -1;
+        }
         int64_t blockId2Write = 0; 
         while (true) {
             RoughIOBlock* outBlockPtr = outputDataPool.get();


### PR DESCRIPTION
修复带参考基因压缩不打包场景解压失败问题
原因：带参考基因压缩不打包参考基因是，base meta中没有参考基因的信息