### PR TITLE
优化文件名命名问题

### DIFF
--- a/src/compress_engine.cpp
+++ b/src/compress_engine.cpp
@@ -99,27 +99,6 @@ bool CompressEngine::initReference() {
             MemoryUtil::safeDeleteClass(pRefGene);
         }
     }
-    // Refresh file meta
-    if (pRefGene) {
-        Json::Value refeMeta;
-        refeMeta["squash_len"] = (Json::Value::Int64)(pRefGene->getSquashLength());
-        refeMeta["fasta_name"] = PathUtil::getFileName(pRefGene->getFastaFileName());
-        refeMeta["fasta_len"] = (Json::Value::Int64)(PathUtil::getFileSize(pRefGene->getFastaFileName()));
-        refeMeta["fasta_md5"] = pRefGene->getFastaChecksum();
-        refeMeta["ni_name"] = PathUtil::getFileName(pRefGene->getNiFilePath()); /* Contains md5 information, used for decompression verification */
-        refeMeta["max_block_len"] = 16 << 20;
-        bool isPackRefeInHeader = !parameter.isUnpackRef && parameter.outputFile == "/dev/stdout";
-        if (isPackRefeInHeader) {
-            refeMeta["blocks"] = calcPackRefeBlockSize();
-            baseFileMeta.setMetaData("refe",refeMeta);
-            int64_t maxRefLen = 0;
-            int64_t totolEncLen = 0;
-            (void)packReference(maxRefLen, totolEncLen, false);
-        } else {
-            refeMeta["blocks"] = 0;
-            baseFileMeta.setMetaData("refe",refeMeta);
-        }
-    }
     return true;
 }
 
@@ -274,4 +253,30 @@ void CompressEngine::setDataBlockPosition(uint32_t blockId) {
     }
 
     return;
+ }
+
+ int32_t CompressEngine::beforeCoderProc() {
+    // Refresh file meta
+    if (pRefGene) {
+        Json::Value refeMeta;
+        refeMeta["squash_len"] = (Json::Value::Int64)(pRefGene->getSquashLength());
+        refeMeta["fasta_name"] = PathUtil::getFileName(pRefGene->getFastaFileName());
+        refeMeta["fasta_len"] = (Json::Value::Int64)(PathUtil::getFileSize(pRefGene->getFastaFileName()));
+        refeMeta["fasta_md5"] = pRefGene->getFastaChecksum();
+        refeMeta["ni_name"] = PathUtil::getFileName(pRefGene->getNiFilePath()); /* Contains md5 information, used for decompression verification */
+        refeMeta["max_block_len"] = 16 << 20;
+        bool isPackRefeInHeader = !parameter.isUnpackRef && parameter.outputFile == "/dev/stdout";
+        if (isPackRefeInHeader) {
+            refeMeta["blocks"] = calcPackRefeBlockSize();
+            baseFileMeta.setMetaData("refe",refeMeta);
+            int64_t maxRefLen = 0;
+            int64_t totolEncLen = 0;
+            (void)packReference(maxRefLen, totolEncLen, false);
+        } else {
+            refeMeta["blocks"] = 0;
+            baseFileMeta.setMetaData("refe",refeMeta);
+        }
+    }
+
+    return 0;
  }

--- a/src/compress_engine.h
+++ b/src/compress_engine.h
@@ -35,6 +35,8 @@ protected:
 
     void startWriteIndexTask();
 
+    virtual int32_t beforeCoderProc();
+
 private:
     bool initReference();
 

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -26,7 +26,7 @@ std::string& ConfigManager::getLogFileName() {
 }
 
 ConfigManager::ConfigManager() {
-    logLevel = LogLevel::INFO;
+    logLevel = LogLevel::OFF;
     logAppender = LogAppender::CONSOLE;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ public:
                         return -1;
                     }
                 }
-                parameter.outputFile = outPath + inFileName + ".pbgz";
+                // parameter.outputFile = outPath + inFileName + ".pbgz";
             }
         } else if (!parameter.outputFile.empty()) {     // File output specified
             // Convert output file to absolute path
@@ -224,7 +224,19 @@ public:
         }
 
         if (parameter.outputFile.empty() && parameter.outputDir.empty()) {
-            parameter.outputFile = PathUtil::getFilePath(parameter.inputFile) + PathUtil::getFileName(parameter.inputFile) + ".pbgz";
+            std::string inputFile = PathUtil::getFileName(parameter.inputFile);
+            if (inputFile.length() > 3 && PathUtil::suffixCheck(inputFile, ".gz")) {
+                inputFile = inputFile.substr(0, inputFile.length() - 3);
+            }
+            parameter.outputFile = PathUtil::getFilePath(parameter.inputFile) + inputFile + ".pbgz";
+        }
+
+        if (!parameter.outputDir.empty() && parameter.outputFile.empty()) {
+            std::string inputFile = PathUtil::getFileName(parameter.inputFile);
+            if (inputFile.length() > 3 && PathUtil::suffixCheck(inputFile, ".gz")) {
+                inputFile = inputFile.substr(0, inputFile.length() - 3);
+            }
+            parameter.outputFile = PathUtil::getFilePath(parameter.outputDir) + inputFile + ".pbgz";
         }
         return 0;
     }
@@ -272,7 +284,7 @@ public:
         if (0 != CommandProc::reconstructPorc()) {
             return -1;
         }
-        if (parameter.outputFile.empty() && parameter.outputDir.empty()) { 
+        if (parameter.outputFile.empty()) { 
             // Decompression scenario, remove pbgz suffix from file
             std::string name = PathUtil::getFileName(parameter.inputFile);
             if (name.length() <= 5) {
@@ -284,8 +296,16 @@ public:
                 return -1;
             }
             name.resize(name.length() - 5);
-            parameter.outputFile = PathUtil::getFilePath(parameter.inputFile) + name;
-        }
+            if (parameter.outputDir.empty()) {
+                parameter.outputFile = PathUtil::getFilePath(parameter.inputFile) + name;
+            } else {
+                parameter.outputFile = PathUtil::getAbsPath(parameter.outputDir) + name;
+            }
+
+            if (parameter.isDecToGZ) {
+                parameter.outputFile = parameter.outputFile + ".gz";
+            }
+        } 
 
         return 0;
     }
@@ -372,7 +392,7 @@ static std::vector<SubCommand> subCommands = {
     {   
         "decompress", 
         "Decompress file from pbgz file",
-        {'h', 'v', 'o', 'O', 'f', 'r', 't', 'e', 'p', 'g', 'G', 'h'},
+        {'h', 'v', 'o', 'O', 'f', 'r', 't', 'e', 'p', 'g', 'G', 'h', 'z'},
         [](PbgzParameter& para) {
             return MemoryUtil::safeNewClass<DecompressCmdProc>(para);
         },
@@ -633,7 +653,6 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    int result = 0;
     if (processor->reconstruct() != 0) {
         LOG_ERROR("Command reconstruction failed");
         return -1;

--- a/src/pbgz_engine.cpp
+++ b/src/pbgz_engine.cpp
@@ -187,6 +187,12 @@ int32_t PbgzEngine::start() {
         return -1;
     }
 
+    ret = beforeCoderProc();
+    if (ret != 0) {
+        LOG_ERROR("Start write task failed.");
+        return -1;
+    }
+
     ret = startCoderTask();
     if (ret != 0) {
         LOG_ERROR("Start coder task failed.");  

--- a/src/pbgz_engine.h
+++ b/src/pbgz_engine.h
@@ -70,6 +70,10 @@ protected:
         return;
     }
 
+    virtual int32_t beforeCoderProc() {
+        return 0;
+    }
+
     virtual BlockReader* createBlockReader() = 0;
 
     virtual BlockWriter* createBlockWriter() = 0;


### PR DESCRIPTION
未指定输出文件名时：
1、压缩场景，如果文件为gz后缀，压缩的pbgz将去掉gz，添加pbgz；不为gz后缀，则只添加pbgz。
2、解压场景，如果文件指定-z参数，解压后的文件名去掉pbgz,添加gz，未指定-z,则只去掉.pbgz。